### PR TITLE
Set TypeScript errors to warn rather than fail the tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
+      diagnostics: {
+        warnOnly: true,
+      },
       tsconfig: {
         rootDir: '.'
       }


### PR DESCRIPTION
### Summary

Use a setting: https://huafu.github.io/ts-jest/user/config/diagnostics

### Motivation

It can be distracting to deal with TS errors you don't care about during an interview, like a type being inferred as `any`.

### Test plan

To trigger a demo of a TS error, I removed the `: number` annotations from the `add` function.

Before:
<img width="865" alt="Screen Shot 2023-01-06 at 6 49 09 PM" src="https://user-images.githubusercontent.com/704302/211118473-e05ed22a-eee5-44e9-8dc7-e8cfbf6d8072.png">

After (with a failing test):
<img width="1082" alt="Screen Shot 2023-01-06 at 6 49 44 PM" src="https://user-images.githubusercontent.com/704302/211118471-1663ed92-25cb-45a2-a686-6823dd2c6559.png">

After (without failing tests, no warnings are printed):
<img width="659" alt="Screen Shot 2023-01-06 at 6 49 25 PM" src="https://user-images.githubusercontent.com/704302/211118472-a1ada575-c273-4756-9645-adeb33d7a499.png">
